### PR TITLE
Added link to `blake2.wasm` that is WebAssembly implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ BLAKE is the default family of hash functions in the venerable NaCl crypto libra
 
 Of course, this implementation is in Javascript, so it won't be winning any speed records. More under Performance below. It's short and sweet, less than 500 LOC.
 
-**As far as I know, this is the only package available today to compute BLAKE in a browser.**
+For WebAssembly implementation with higher performance you might want to consider [blake2.wasm](https://github.com/nazar-pc/blake2.wasm) instead.
 
 Quick Start
 ---


### PR DESCRIPTION
I've added link to this repo from my blake2.wasm repo, would you like to add similar link too?

I've adjusted your speed test to my implementation and got:
```
nazar-pc@nazar-pc /w/g/blake2.wasm> node speed-test.js 
Benchmarking BLAKE2b(4 MB input)
Generated random input in 6ms
Hashed in 30ms: 2df49b96ca3ba3410467...
133.33 MB PER SECOND
Hashed in 29ms: 2df49b96ca3ba3410467...
137.93 MB PER SECOND
Hashed in 29ms: 2df49b96ca3ba3410467...
137.93 MB PER SECOND
```

My system is i7-8700k @4.8GHz, but it is nowhere near an order of magnitude faster for single-threaded tasks than i7-4770HQ 😉 