### PR TITLE
Don't depend on Buffer to be compatible with Webpack 5 by default

### DIFF
--- a/util.js
+++ b/util.js
@@ -5,10 +5,9 @@ function normalizeInput (input) {
   let ret
   if (input instanceof Uint8Array) {
     ret = input
-  } else if (input instanceof Buffer) {
-    ret = new Uint8Array(input)
   } else if (typeof input === 'string') {
-    ret = new Uint8Array(Buffer.from(input, 'utf8'))
+    const encoder = new TextEncoder()
+    ret = encoder.encode(input)
   } else {
     throw new Error(ERROR_MSG_INPUT)
   }


### PR DESCRIPTION
I have problems using this package in a project created by [`create-react-app@5`](https://www.npmjs.com/package/create-react-app).

Reproduction: https://github.com/davidyuk/reproductions/tree/cra-5-blakejs

The error I have (in browser console):
> Uncaught ReferenceError: Buffer is not defined
    at Object.normalizeInput (util.js:10:1)
    at blake2b (blake2b.js:441:1)

It happens because Webpack 5 dropped automatic polyfilling of Nodejs modules: https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed. It can be fixed in webpack configuration, but it can't be changed without ejecting the react project (that some users may not want to do for simplicity).

Since node@4, [`Buffer` inherits `Uint8Array`](https://nodejs.org/docs/latest-v4.x/api/buffer.html#buffer_buffer), so a separate `input instanceof Buffer` check is extra and I'm proposing to remove it.

Regarding the second reference to `Buffer`: let's use `TextEncoder` class, it is [widely supported](https://caniuse.com/textencoder) now (except for IE 11). If necessary it can be polyfilled on a side of the project that uses this library.

As an alternative to the proposed fix, `blakejs` can explicitly depend on [`buffer`](https://www.npmjs.com/package/buffer) package.