### PR TITLE
fix: Add missing parameters in types definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,13 +6,17 @@ export interface Blake2bCTX {
     outlen: number;
 }
 
+type InputBytes = string | Uint8Array;
+
 /**
  * Creates a Blake2b hashing context
  * @param outlen between 1 and 64
  * @param key optional
+ * @param salt optional salt bytes, string, Buffer or Uint8Array
+ * @param personal optional personal bytes, string, Buffer or Uint8Array
  * @returns the hashing context
  */
-export declare function blake2bInit(outlen?: number, key?: Uint8Array): Blake2bCTX;
+export declare function blake2bInit(outlen?: number, key?: Uint8Array, salt?: InputBytes, personal?: InputBytes): Blake2bCTX;
 
 /**
  * Updates a Blake2b streaming hash
@@ -32,20 +36,24 @@ export declare function blake2bFinal(ctx: Blake2bCTX): Uint8Array;
  *
  * @param input the input bytes, as a string, Buffer, or Uint8Array
  * @param key optional key Uint8Array, up to 64 bytes
- * @param outlen optional output length in bytes, defaults to 64
+ * @param outlen optional output length in bytes, default 64
+ * @param salt optional salt bytes, string, Buffer or Uint8Array
+ * @param personal optional personal bytes, string, Buffer or Uint8Array
  * @returns an n-byte Uint8Array
  */
-export declare function blake2b(input: string | Uint8Array, key?: Uint8Array, outlen?: number): Uint8Array;
+export declare function blake2b(input: InputBytes, key?: Uint8Array, outlen?: number, salt?: InputBytes, personal?: InputBytes): Uint8Array;
 
 /**
  * Computes the Blake2b hash of a string or byte array
  *
  * @param input the input bytes, as a string, Buffer, or Uint8Array
  * @param key optional key Uint8Array, up to 64 bytes
- * @param outlen outlen - optional output length in bytes, defaults to 64
+ * @param outlen optional output length in bytes, default 64
+ * @param salt optional salt bytes, string, Buffer or Uint8Array
+ * @param personal optional personal bytes, string, Buffer or Uint8Array
  * @returns an n-byte hash in hex, all lowercase
  */
-export declare function blake2bHex(input: string | Uint8Array, key?: Uint8Array, outlen?: number): string;
+export declare function blake2bHex(input: InputBytes, key?: Uint8Array, outlen?: number, salt?: InputBytes, personal?: InputBytes): string;
 
 export interface Blake2sCTX {
     h: Uint32Array;
@@ -84,7 +92,7 @@ export declare function blake2sFinal(ctx: Blake2sCTX): Uint8Array;
  * @param outlen optional output length in bytes, defaults to 64
  * @returns an n-byte Uint8Array
  */
-export declare function blake2s(input: string | Uint8Array, key?: Uint8Array, outlen?: number): Uint8Array;
+export declare function blake2s(input: InputBytes, key?: Uint8Array, outlen?: number): Uint8Array;
 
 /**
  *
@@ -93,4 +101,4 @@ export declare function blake2s(input: string | Uint8Array, key?: Uint8Array, ou
  * @param outlen optional output length in bytes, defaults to 64
  * @returns an n-byte hash in hex, all lowercase
  */
-export declare function blake2sHex(input: string | Uint8Array, key?: Uint8Array, outlen?: number): string;
+export declare function blake2sHex(input: InputBytes, key?: Uint8Array, outlen?: number): string;


### PR DESCRIPTION
followup for 5a2c908e5efdf0d844250ab213e3c7395530a4e6

adding missing parameters in typescript definitions